### PR TITLE
Fixed incorrect link to the codesniffer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ checks code against the coding standards used in Submitty.
 You should install this using composer:
 
 ```bash
-composer require --dev submitty/submitty-php-codesniffer
+composer require --dev submitty/php-codesniffer
 ```


### PR DESCRIPTION
The package on the php package list is submitty/php-codesniffer but the docs list it as being submitty/submitty-php-codesniffer which does not seem to exist

The package in Packagist that I think is supposed to be referred to.
https://packagist.org/packages/submitty/php-codesniffer